### PR TITLE
Use crypto-helper with fix: base64 conversion of Hash

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -356,8 +356,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/alamgu/ledger-crypto-helpers";
-          rev = "22a454e9b81615053928fb6b21d59b45c2a1e498";
-          sha256 = "0fagq3kqmarkr7pnbd15d56nm3xpsgfrfqkywxladihym87dzdxm";
+          rev = "9fdebe4d062375ade88ee8ed4d8817d73e7faa48";
+          sha256 = "09d4ihis46q16n4a6wq0wrirh14kyl5ffjsfz3q75xlq62dcqcqn";
         };
         dependencies = [
           {

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,6 +1,6 @@
 {
   "enum-init 0.1.0 (git+https://github.com/alamgu/enum-init#a831c2fbbe00af926ae87c064bfe4da58d26777c)": "1daqa7i1778rpvk8d442flk6bak6jxi6hrcc5j4maaa7ipjc6xlr",
-  "ledger-crypto-helpers 0.2.0 (git+https://github.com/alamgu/ledger-crypto-helpers#22a454e9b81615053928fb6b21d59b45c2a1e498)": "0fagq3kqmarkr7pnbd15d56nm3xpsgfrfqkywxladihym87dzdxm",
+  "ledger-crypto-helpers 0.2.0 (git+https://github.com/alamgu/ledger-crypto-helpers?branch=dn-hash-stack-fix#9fdebe4d062375ade88ee8ed4d8817d73e7faa48)": "09d4ihis46q16n4a6wq0wrirh14kyl5ffjsfz3q75xlq62dcqcqn",
   "ledger-log 0.2.0 (git+https://github.com/alamgu/ledger-log#02f702bbec9ca9802151fd261508580eb3826287)": "03qic29qkvis54bgh40wwja89kcp6kz6acd0ifzyvcqxicpmikmy",
   "ledger-parser-combinators 0.1.0 (git+https://github.com/alamgu/ledger-parser-combinators#c7ee244c322d42cfaf2ef124170a6e695d208b6b)": "1h7aghm8zvs3ymv19h6rczripgsa13n27cqwzzz2jnc7r2463n34",
   "ledger-prompts-ui 0.1.0 (git+https://github.com/alamgu/ledger-prompts-ui#24d2f36da07131074211559cd28f235c3f7c9984)": "0gy73gv2vrajyrzigr2iwfnw0gmj1wfpig0xlbhw1vpkpjg23w0q",

--- a/rust-app/Cargo.lock
+++ b/rust-app/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 [[package]]
 name = "ledger-crypto-helpers"
 version = "0.2.0"
-source = "git+https://github.com/alamgu/ledger-crypto-helpers#22a454e9b81615053928fb6b21d59b45c2a1e498"
+source = "git+https://github.com/alamgu/ledger-crypto-helpers?branch=dn-hash-stack-fix#9fdebe4d062375ade88ee8ed4d8817d73e7faa48"
 dependencies = [
  "arrayvec",
  "base64",

--- a/rust-app/Cargo.toml
+++ b/rust-app/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [dependencies]
 arrayvec = { version = "0.7.2", default-features = false }
 base64 = { version = "0.13.0", default-features = false }
-ledger-crypto-helpers = { git = "https://github.com/alamgu/ledger-crypto-helpers" }
+ledger-crypto-helpers = { git = "https://github.com/alamgu/ledger-crypto-helpers", branch = "dn-hash-stack-fix" }
 ledger-log = { git = "https://github.com/alamgu/ledger-log" }
 ledger-parser-combinators = { git = "https://github.com/alamgu/ledger-parser-combinators" }
 zeroize = { version = "1.5.2", default-features = false }


### PR DESCRIPTION
This fix is to reduce stack size usage in one of the libraries APIs when showing transaction hash, and is necessary for NanoS.